### PR TITLE
Release

### DIFF
--- a/code/api/integration.py
+++ b/code/api/integration.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from ssl import SSLCertVerificationError
 from urllib.parse import urljoin
 
+import datetime
 import requests
 from flask import current_app
 from requests.exceptions import SSLError
@@ -111,22 +112,36 @@ def get_events_for_detection(key, detection_uuid):
     return events, None
 
 
+def mil_time(date):
+    return str(date)[:-3]+'Z'
+
+
 def get_events(key, observable):
     url = _url('event', 'query')
 
     limit = current_app.config['CTR_ENTITIES_LIMIT']
+    events = []
+    now = datetime.datetime.now()
+    end_date = now.isoformat()
+    start_date = (now - datetime.timedelta(days=1)).isoformat()
+    day_range = current_app.config['DAY_RANGE']
+    while day_range and len(events) < limit:
+        json = {
+            'query': f"{observable['type']} = '{observable['value']}'",
+            'start_date': mil_time(start_date),
+            'end_date': mil_time(end_date)
+        }
+        data, error = _request('POST', url, key=key, json=json)
+        if error:
+            return None, error
+        end_date, start_date = start_date, (
+            datetime.datetime.fromisoformat(start_date) -
+            datetime.timedelta(days=1)
+        ).isoformat()
+        events.extend(data['events'])
+        day_range -= 1
 
-    json = {
-        'query': f"{observable['type']} = '{observable['value']}'",
-        'limit': limit,
-    }
-
-    data, error = _request('POST', url, key=key, json=json)
-
-    if error:
-        return None, error
-
-    events = data['events']
+    events = events[:limit]
 
     return events, None
 

--- a/code/api/utils.py
+++ b/code/api/utils.py
@@ -1,5 +1,5 @@
 import json
-
+from json.decoder import JSONDecodeError
 import jwt
 import requests
 from jwt import InvalidSignatureError, InvalidAudienceError, DecodeError
@@ -55,6 +55,7 @@ def get_public_key(jwks_host, token):
     expected_errors = {
         ConnectionError: WRONG_JWKS_HOST,
         InvalidURL: WRONG_JWKS_HOST,
+        JSONDecodeError: WRONG_JWKS_HOST,
     }
     try:
         response = requests.get(f"https://{jwks_host}/.well-known/jwks")

--- a/code/config.py
+++ b/code/config.py
@@ -39,3 +39,5 @@ class Config:
         'dmo', '6bc3d2f1-af77-4236-a9db-17dacd06e4d9',  # Demo
         'chg', 'f6f6f836-8bcd-4f5d-bd61-68d303c4f634',  # Training
     }
+
+    DAY_RANGE = 7  # Default day range for Gigamon API events search

--- a/code/container_settings.json
+++ b/code/container_settings.json
@@ -1,1 +1,1 @@
-{"VERSION": "2.0.0","NAME": "Gigamon ThreatINSIGHT"}
+{"VERSION": "2.0.1","NAME": "Gigamon ThreatINSIGHT"}

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -6,3 +6,4 @@ coverage==5.5.0
 pytest==6.2.2
 cryptography==3.3.2
 pyjwt[crypto]==2.0.1
+Werkzeug==1.0.1

--- a/module_type.json.sample
+++ b/module_type.json.sample
@@ -6,10 +6,6 @@
     "tips": "When configuring the Gigamon ThreatINSIGHT integration, you must first gather some information from your Gigamon ThreatINSIGHT account.\n\n1. Log into Gigamon ThreatINSIGHT, click **Settings Icon** and choose **Profile Settings**.\n2. Click **Create New Token**, provide a **Description** and click **Create**.\n3. Copy the **Token** into a file, or leave the tab open. **Important:** Do not close the dialog without retrieving the token; the token is not retrievable once the dialog is closed.\n4. Complete the **Add New Gigamon ThreatINSIGHT Module** form:\n    - **Module Name** - Leave the default name or enter a name that is meaningful to you.\n    - **URL** - The URL of the Gigamon ThreatINSIGHT Serverless Relay.\n    - **API KEY** - Enter the Gigamon ThreatINSIGHT API Key.\n    - **CTR ENTITIES LIMIT** - Enter the limit that restricts the maximum number of CTIM entities of each type returned in a single response per each requested observable. Must be a positive integer. Defaults to 100 (if unset or incorrect). Has the upper bound of 1000 to avoid getting overwhelmed with too much data, so any greater values are still acceptable but also limited at the same time.\n    - **GTI_ALLOW_TEST_ACCOUNTS** - Allows fake data from the test accounts (Demo and Training) to be returned along with real data (if enabled).\n6. Click **Save** to complete the Gigamon ThreatINSIGHT module configuration.",
     "external_references": [
         {
-            "label": "Free Trial",
-            "link": "https://www.gigamon.com/lp/threatinsight-self-guided-demo.html?utm_campaign=cisco&utm_source=ti-module&utm_medium=referral"
-        },
-        {
             "label": "Learn More",
             "link": "https://www.gigamon.com/products/detect-respond/gigamon-threatinsight.html?utm_campaign=cisco&utm_source=ti-module&utm_medium=referral"
         },

--- a/module_type.json.sample
+++ b/module_type.json.sample
@@ -38,7 +38,7 @@
             "key": "custom_CTR_ENTITIES_LIMIT",
             "type": "integer",
             "label": "CTR ENTITIES LIMIT",
-            "tooltip": "Restricts the maximum number of `Indicators` and `Sightings`",
+            "tooltip": "Restricts the maximum number of `Sightings` and `Indicators`. Please note that the number over 100 might lead to data inconsistency.",
             "required": false
         },
         {


### PR DESCRIPTION
- Add 404 error handling.

- Accordingly to https://github.com/CiscoSecurity/tr-05-serverless-gigamon-threatinsight/issues/45, default request grabbing data for 7 last days and filtering 100 events was replaced for up to 7 separate daily requests grabbing data for 100 last events.  That can helps to improve response time.